### PR TITLE
Update sources.py

### DIFF
--- a/miepy/sources/sources.py
+++ b/miepy/sources/sources.py
@@ -174,7 +174,7 @@ class polarized_propagating_source(propagating_source):
     def __init__(self, polarization, amplitude=1, phase=0, origin=None, theta=0, phi=0, standing=False):
         propagating_source.__init__(self, amplitude=amplitude, phase=phase, origin=origin, theta=theta, phi=phi, standing=standing)
 
-        self.polarization = np.asarray(polarization, dtype=np.complex)
+        self.polarization = np.asarray(polarization, dtype=complex)
         self.polarization /= np.linalg.norm(self.polarization)
 
     @abstractmethod


### PR DESCRIPTION
To address depreciation warning:
DeprecationWarning: `np.complex` is a deprecated alias for the builtin `complex`. To silence this warning, use `complex` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.complex128` here.